### PR TITLE
fixed _getKernelBitness for "macos"

### DIFF
--- a/lib/src/system_info.dart
+++ b/lib/src/system_info.dart
@@ -277,7 +277,7 @@ abstract class SysInfo {
 
         return 32;
       case "macos":
-        if (_fluent(_exec("uname", ["-m"])).trim() == "x86_64") {
+        if (_fluent(_exec("uname", ["-m"])).trim().stringValue == "x86_64") {
           return 64;
         }
 


### PR DESCRIPTION
I fixed missing `stringValue` in `_getKernelBitness()` for OS X.

I also noticed some weird escape characters at the end of a few lines. These are probably generated by some Windows IDE. I didn't want to remove them by myself because this would made a huge commit, so I'll leave it up to you :).
http://stackoverflow.com/questions/5843495/what-does-m-character-mean-in-vim

![screen shot 2015-06-15 at 21 23 17](https://cloud.githubusercontent.com/assets/238765/8168679/c6d89144-13a4-11e5-9336-6ac8dc0f7851.png)