### PR TITLE
Fixes available physical memory in Linux

### DIFF
--- a/lib/src/system_info.dart
+++ b/lib/src/system_info.dart
@@ -158,7 +158,7 @@ abstract class SysInfo {
             .trim()
             .stringToMap(':')
             .mapValue;
-        final value = _fluent(data['MemFree'])
+        final value = _fluent(data['MemAvailable'])
             .split(' ')
             .elementAt(0)
             .parseInt()
@@ -183,7 +183,7 @@ abstract class SysInfo {
             .trim()
             .stringToMap(':')
             .mapValue;
-        final physical = _fluent(data['MemFree'])
+        final physical = _fluent(data['MemAvailable'])
             .split(' ')
             .elementAt(0)
             .parseInt()


### PR DESCRIPTION
Uses MemAvailable instead of MemFree
MemFree value is not available RAM in Linux (tested in ubuntu 18.04)